### PR TITLE
Fix several warnings

### DIFF
--- a/HttpStream/CacheStream.cs
+++ b/HttpStream/CacheStream.cs
@@ -1,10 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Threading;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Espresso3389.HttpStream
@@ -392,9 +389,9 @@ namespace Espresso3389.HttpStream
             return bytesRead;
         }
 
-        public override Task FlushAsync(System.Threading.CancellationToken cancellationToken) => throw new NotSupportedException();
+        public override Task FlushAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, System.Threading.CancellationToken cancellationToken) => throw new NotSupportedException();
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => throw new NotSupportedException();
     }
 }
 

--- a/HttpStream/HttpStream.csproj
+++ b/HttpStream/HttpStream.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Espresso3389.HttpStream</RootNamespace>
     <Version Condition=" '$(ASMVER)' == '' ">2.0.0</Version>
     <Version Condition=" '$(ASMVER)' != '' ">$(ASMVER)</Version>
     <PackageId>Espresso3389.HttpStream</PackageId>

--- a/HttpStreamTest/HttpStreamTest.csproj
+++ b/HttpStreamTest/HttpStreamTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Namespace does not correspond to file location, should be: 'HttpStream'
* Using directive is not required by the code and can be safely removed
* Qualifier is redundant
* Cannot resolve symbol 'FileSizeAvailable'
* Cannot resolve symbol 'BufferingSize should be 2^n.'
* Parameter 'cachePageSize' has no matching param tag in the XML comment for Espresso3389.HttpStream.HttpStream.HttpStream (but other parameters do)
* Parameter 'cached' has no matching param tag in the XML comment for Espresso3389.HttpStream.HttpStream.HttpStream (but other parameters do)
* Value assigned is not used in any execution path
* [NETSDK1138] The target framework 'netcoreapp2.1' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.