### PR TITLE
Add CreateAsync static methods and obsolete all HttpStream constructors

### DIFF
--- a/HttpStream/HttpStream.CreateAsync.cs
+++ b/HttpStream/HttpStream.CreateAsync.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Espresso3389.HttpStream
+{
+    public partial class HttpStream
+    {
+        /// <summary>
+        /// Creates a new HttpStream with the specified URI.
+        /// The file will be cached on memory.
+        /// </summary>
+        /// <param name="uri">URI of the file to download.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public static async Task<HttpStream> CreateAsync(Uri uri, CancellationToken cancellationToken = default)
+        {
+            return await CreateAsync(uri, new MemoryStream(), true, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new HttpStream with the specified URI.
+        /// </summary>
+        /// <param name="uri">URI of the file to download.</param>
+        /// <param name="cache">Stream, on which the file will be cached. It should be seekable, readable and writeable.</param>
+        /// <param name="ownStream"><c>true</c> to dispose <paramref name="cache"/> on HttpStream's cleanup.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public static async Task<HttpStream> CreateAsync(Uri uri, Stream cache, bool ownStream, CancellationToken cancellationToken = default)
+        {
+            return await CreateAsync(uri, cache, ownStream, DefaultCachePageSize, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new HttpStream with the specified URI.
+        /// </summary>
+        /// <param name="uri">URI of the file to download.</param>
+        /// <param name="cache">Stream, on which the file will be cached. It should be seekable, readable and writeable.</param>
+        /// <param name="ownStream"><c>true</c> to dispose <paramref name="cache"/> on HttpStream's cleanup.</param>
+        /// <param name="cachePageSize">Cache page size.</param>
+        /// <param name="cached">Cached flags for the pages in packed bits if any; otherwise it can be <c>null</c>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public static async Task<HttpStream> CreateAsync(Uri uri, Stream cache, bool ownStream, int cachePageSize, byte[]? cached, CancellationToken cancellationToken = default)
+        {
+            return await CreateAsync(uri, cache, ownStream, cachePageSize, cached, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new HttpStream with the specified URI.
+        /// </summary>
+        /// <param name="uri">URI of the file to download.</param>
+        /// <param name="cache">Stream, on which the file will be cached. It should be seekable, readable and writeable.</param>
+        /// <param name="ownStream"><c>true</c> to dispose <paramref name="cache"/> on HttpStream's cleanup.</param>
+        /// <param name="cachePageSize">Cache page size.</param>
+        /// <param name="cached">Cached flags for the pages in packed bits if any; otherwise it can be <c>null</c>.</param>
+        /// <param name="httpClient"><see cref="HttpClient"/> to use on creating HTTP requests or <c>null</c> to use a default <see cref="HttpClient"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public static async Task<HttpStream> CreateAsync(Uri uri, Stream cache, bool ownStream, int cachePageSize, byte[]? cached, HttpClient? httpClient, CancellationToken cancellationToken = default)
+        {
+            return await CreateAsync(uri, cache, ownStream, cachePageSize, cached, httpClient, null, cancellationToken);
+        }
+
+        /// <summary>
+        /// Creates a new HttpStream with the specified URI.
+        /// </summary>
+        /// <param name="uri">URI of the file to download.</param>
+        /// <param name="cache">Stream, on which the file will be cached. It should be seekable, readable and writeable.</param>
+        /// <param name="ownStream"><c>true</c> to dispose <paramref name="cache"/> on HttpStream's cleanup.</param>
+        /// <param name="cachePageSize">Cache page size.</param>
+        /// <param name="cached">Cached flags for the pages in packed bits if any; otherwise it can be <c>null</c>.</param>
+        /// <param name="httpClient"><see cref="HttpClient"/> to use on creating HTTP requests or <c>null</c> to use a default <see cref="HttpClient"/>.</param>
+        /// <param name="dispatcherInvoker">Function called on every call to synchronous <see cref="HttpStream.Read(byte[], int, int)"/> call to invoke <see cref="HttpStream.ReadAsync(byte[], int, int, CancellationToken)"/>.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        public static async Task<HttpStream> CreateAsync(Uri uri, Stream cache, bool ownStream, int cachePageSize, byte[]? cached, HttpClient? httpClient, DispatcherInvoker? dispatcherInvoker, CancellationToken cancellationToken = default)
+        {
+#pragma warning disable 618
+            var httpStream = new HttpStream(uri, cache, ownStream, cachePageSize, cached, httpClient, dispatcherInvoker);
+#pragma warning restore 618
+            using var headResponse = await httpStream._httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, uri), cancellationToken);
+            var contentLength = headResponse.Content.Headers.ContentLength;
+            if (contentLength.HasValue)
+            {
+                httpStream.StreamLength = contentLength.Value;
+                httpStream.IsStreamLengthAvailable = true;
+            }
+            return httpStream;
+        }
+    }
+}
+

--- a/HttpStream/HttpStream.cs
+++ b/HttpStream/HttpStream.cs
@@ -13,7 +13,7 @@ namespace Espresso3389.HttpStream
     /// <summary>
     /// Implements randomly accessible <see cref="Stream"/> on HTTP 1.1 transport.
     /// </summary>
-    public class HttpStream : CacheStream
+    public partial class HttpStream : CacheStream
     {
         readonly Uri _uri;
         readonly HttpClient _httpClient;
@@ -65,6 +65,7 @@ namespace Espresso3389.HttpStream
         /// The file will be cached on memory.
         /// </summary>
         /// <param name="uri">URI of the file to download.</param>
+        [Obsolete("Please use the CreateAsync(Uri, CancellationToken) static method instead.")]
         public HttpStream(Uri uri) : this(uri, new MemoryStream(), true)
         {
         }
@@ -80,6 +81,7 @@ namespace Espresso3389.HttpStream
         /// <param name="uri">URI of the file to download.</param>
         /// <param name="cache">Stream, on which the file will be cached. It should be seekable, readable and writeable.</param>
         /// <param name="ownStream"><c>true</c> to dispose <paramref name="cache"/> on HttpStream's cleanup.</param>
+        [Obsolete("Please use the CreateAsync(Uri, Stream, bool, CancellationToken) static method instead.")]
         public HttpStream(Uri uri, Stream cache, bool ownStream) : this(uri, cache, ownStream, DefaultCachePageSize, null)
         {
         }
@@ -92,6 +94,7 @@ namespace Espresso3389.HttpStream
         /// <param name="ownStream"><c>true</c> to dispose <paramref name="cache"/> on HttpStream's cleanup.</param>
         /// <param name="cachePageSize">Cache page size.</param>
         /// <param name="cached">Cached flags for the pages in packed bits if any; otherwise it can be <c>null</c>.</param>
+        [Obsolete("Please use the CreateAsync(Uri, Stream, bool, int, byte[]?, CancellationToken) static method instead.")]
         public HttpStream(Uri uri, Stream cache, bool ownStream, int cachePageSize, byte[]? cached)
             : this(uri, cache, ownStream, cachePageSize, cached, null)
         {
@@ -106,6 +109,7 @@ namespace Espresso3389.HttpStream
         /// <param name="cachePageSize">Cache page size.</param>
         /// <param name="cached">Cached flags for the pages in packed bits if any; otherwise it can be <c>null</c>.</param>
         /// <param name="httpClient"><see cref="HttpClient"/> to use on creating HTTP requests or <c>null</c> to use a default <see cref="HttpClient"/>.</param>
+        [Obsolete("Please use the CreateAsync(Uri, Stream, bool, int, byte[]?, HttpClient?, CancellationToken) static method instead.")]
         public HttpStream(Uri uri, Stream cache, bool ownStream, int cachePageSize, byte[]? cached, HttpClient? httpClient)
             : this(uri, cache, ownStream, cachePageSize, cached, httpClient, null)
         {
@@ -121,6 +125,7 @@ namespace Espresso3389.HttpStream
         /// <param name="cached">Cached flags for the pages in packed bits if any; otherwise it can be <c>null</c>.</param>
         /// <param name="httpClient"><see cref="HttpClient"/> to use on creating HTTP requests or <c>null</c> to use a default <see cref="HttpClient"/>.</param>
         /// <param name="dispatcherInvoker">Function called on every call to synchronous <see cref="HttpStream.Read(byte[], int, int)"/> call to invoke <see cref="HttpStream.ReadAsync(byte[], int, int, CancellationToken)"/>.</param>
+        [Obsolete("Please use the CreateAsync(Uri, Stream, bool, int, byte[]?, HttpClient?, DispatcherInvoker?, CancellationToken) static method instead.")]
         public HttpStream(Uri uri, Stream cache, bool ownStream, int cachePageSize, byte[]? cached, HttpClient? httpClient, DispatcherInvoker? dispatcherInvoker)
             : base(cache, ownStream, cachePageSize, cached, dispatcherInvoker)
         {

--- a/HttpStream/HttpStream.csproj
+++ b/HttpStream/HttpStream.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
     <RootNamespace>Espresso3389.HttpStream</RootNamespace>
     <Version Condition=" '$(ASMVER)' == '' ">2.0.0</Version>
     <Version Condition=" '$(ASMVER)' != '' ">$(ASMVER)</Version>


### PR DESCRIPTION
Doing so, we can avoid doing dangerous [sync over async][1] when accessing the [Stream.Length][2] for the first time since the `HttpStream.StreamLength` will already be known.

The code path will be

```
CacheStream.Length
  Wait
    GetLengthAsync
      GetStreamLengthOrDefault
```

The `await WrapTask(readAsync(0L, new byte[1], 0, 1, CancellationToken.None));` will **not** be called so `return func().Result` is safe to call at that point since we know that the `Result` is already computed.

Note that this pull request is dependent on #4.

[1]: https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#warning-sync-over-async
[2]: https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.length