### PR TITLE
64-bit support (allow long offset)

### DIFF
--- a/HttpStream/CacheStream.cs
+++ b/HttpStream/CacheStream.cs
@@ -298,7 +298,7 @@ namespace Espresso3389.HttpStream
         /// <param name="length">The length of the data to download.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The byte range actually loaded. It may be larger than the requested range.</returns>
-        protected abstract Task<int> LoadAsync(Stream stream, int offset, int length, CancellationToken cancellationToken);
+        protected abstract Task<int> LoadAsync(Stream stream, long offset, int length, CancellationToken cancellationToken);
 
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
@@ -339,7 +339,7 @@ namespace Espresso3389.HttpStream
                         }
                     }
 
-                    var offsetToLoad = i * _cachePageSize;
+                    var offsetToLoad = (long)i * _cachePageSize;
                     var sizeToLoad = pagesNotCached * _cachePageSize;
 
                     var sizeLoaded = await WrapTask(LoadAsync(_cacheStream, offsetToLoad, sizeToLoad, cancellationToken));

--- a/HttpStream/HttpStream.cs
+++ b/HttpStream/HttpStream.cs
@@ -185,7 +185,7 @@ namespace Espresso3389.HttpStream
         /// <param name="length">The length of the data to download.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The byte range actually downloaded. It may be larger than the requested range.</returns>
-        protected override async Task<int> LoadAsync(Stream stream, int offset, int length, CancellationToken cancellationToken)
+        protected override async Task<int> LoadAsync(Stream stream, long offset, int length, CancellationToken cancellationToken)
         {
             if (length == 0)
                 return 0;


### PR DESCRIPTION
This intends to resolve #7.

NOTE: To actually make use of this it's required to use another cache stream than MemoryStream because it in itself is limited to 32-bits. In my own usage https://github.com/microsoft/Microsoft.IO.RecyclableMemoryStream has been working great as a replacement.