### PR TITLE
Use HttpCompletionOption.ResponseHeadersRead

### DIFF
--- a/HttpStream/HttpStream.CreateAsync.cs
+++ b/HttpStream/HttpStream.CreateAsync.cs
@@ -76,7 +76,7 @@ namespace Espresso3389.HttpStream
 #pragma warning disable 618
             var httpStream = new HttpStream(uri, cache, ownStream, cachePageSize, cached, httpClient, dispatcherInvoker);
 #pragma warning restore 618
-            using var headResponse = await httpStream._httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, uri), cancellationToken);
+            using var headResponse = await httpStream._httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, uri), HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             var contentLength = headResponse.Content.Headers.ContentLength;
             if (contentLength.HasValue)
             {

--- a/HttpStream/HttpStream.cs
+++ b/HttpStream/HttpStream.cs
@@ -199,7 +199,7 @@ namespace Espresso3389.HttpStream
             req.Headers.Add("Range", $"bytes={offset}-{endPos - 1}");
 
             // post the request
-            var res = await _httpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
+            var res = await _httpClient.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             LastHttpStatusCode = res.StatusCode;
             LastReasonPhrase = res.ReasonPhrase;
             if (!res.IsSuccessStatusCode)


### PR DESCRIPTION
I suspect use with external httpclient multiple times will lead to memory leak and that what is described at https://www.stevejgordon.co.uk/using-httpcompletionoption-responseheadersread-to-improve-httpclient-performance-dotnet should apply here.

Even with "own" httpclient it should be more efficient with ResponseHeadersRead.

However I haven't been able to test this properly yet.