### PR TITLE
Fix reading the data when the stream length is not available

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,6 +11,10 @@ on:
 
   workflow_dispatch:
 
+env:
+  Configuration: Release
+  ContinuousIntegrationBuild: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -24,14 +28,21 @@ jobs:
         run: ./scripts/gitrev.sh
 
       - name: Build the assembly
-        run: |
-          cd HttpStream
-          dotnet build --configuration Release HttpStream.csproj -p:ASM_VER=${{ env.ASM_VER }} -p:ASM_COMMIT=${{ env.ASM_COMMIT }} -p:ASM_BUILD_FOR=${{ env.ASM_BUILD_FOR }}
+        run: dotnet build -p:ASM_VER=${{ env.ASM_VER }} -p:ASM_COMMIT=${{ env.ASM_COMMIT }} -p:ASM_BUILD_FOR=${{ env.ASM_BUILD_FOR }}
+
+      - name: Run the tests
+        run: dotnet test
+
+      - name: Generate the test report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: Test Results
+          path: '*.trx'
+          reporter: dotnet-trx
 
       - name: Create the package
-        run: |
-          cd HttpStream
-          dotnet pack --configuration Release HttpStream.csproj
+        run: dotnet pack
 
       - name: Upload the package as an artifact anyway
         uses: actions/upload-artifact@v4

--- a/HttpStream.Tests/HttpStream.Tests.csproj
+++ b/HttpStream.Tests/HttpStream.Tests.csproj
@@ -17,4 +17,9 @@
     <ProjectReference Include="..\HttpStream\HttpStream.csproj" />
   </ItemGroup>
 
+  <PropertyGroup Condition="$(ContinuousIntegrationBuild) == 'true'">
+    <VSTestLogger>trx%3BLogFileName=TestResults-$(TargetFramework).trx</VSTestLogger>
+    <VSTestResultsDirectory>$([System.IO.Directory]::GetParent($(MSBuildProjectDirectory)))</VSTestResultsDirectory>
+  </PropertyGroup>
+
 </Project>

--- a/HttpStream.Tests/HttpStream.Tests.csproj
+++ b/HttpStream.Tests/HttpStream.Tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>HttpStreamTests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="9.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\HttpStream\HttpStream.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/HttpStream.Tests/WebAppFixture.cs
+++ b/HttpStream.Tests/WebAppFixture.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace HttpStreamTests;
+
+public class WebAppFixture : IAsyncLifetime
+{
+    private readonly WebApplication _webApp;
+    private Uri? _uri;
+
+    public WebAppFixture()
+    {
+        var webAppBuilder = WebApplication.CreateBuilder();
+        webAppBuilder.Services.AddResponseCompression();
+        webAppBuilder.WebHost.UseUrls("http://127.0.0.1:0");
+
+        _webApp = webAppBuilder.Build();
+        _webApp.UseResponseCompression();
+        _webApp.MapMethods("/bytes/{size:int}", [HttpMethods.Get, HttpMethods.Head], (int size) => TypedResults.File(Enumerable.Repeat(Convert.ToByte('A'), size).ToArray(), MediaTypeNames.Text.Plain));
+    }
+
+    /// <summary>
+    /// Returns a URI that sends a <c>text/plain</c> response of the character <c>A</c> repeated <paramref name="size"/> times.
+    /// </summary>
+    /// <param name="size">The size of the response content in bytes.</param>
+    public Uri GetBytesUri(int size)
+    {
+        var baseUri = _uri ?? throw new InvalidOperationException($"The URI is only available after {nameof(IAsyncLifetime.InitializeAsync)} has been called");
+        return new Uri(baseUri, $"/bytes/{size}");
+    }
+
+    async Task IAsyncLifetime.InitializeAsync()
+    {
+        await _webApp.StartAsync();
+
+        var server = _webApp.Services.GetRequiredService<IServer>();
+        var serverAddress = server.Features.Get<IServerAddressesFeature>() ?? throw new InvalidOperationException($"Could not get the server addresses feature from {server}");
+        _uri = new Uri(serverAddress.Addresses.Single());
+    }
+
+    async Task IAsyncLifetime.DisposeAsync()
+    {
+        await _webApp.StopAsync();
+    }
+}

--- a/HttpStream.sln
+++ b/HttpStream.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28010.2046
@@ -6,6 +6,8 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HttpStream", "HttpStream\HttpStream.csproj", "{072FEEA8-897B-4C81-A82A-4D85B82B2101}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpStreamTest", "HttpStreamTest\HttpStreamTest.csproj", "{1C2C22B6-C3F1-4376-90A1-46B46669BFEC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpStream.Tests", "HttpStream.Tests\HttpStream.Tests.csproj", "{2225358D-0A9F-4AB4-B678-B22FE5E1A8CF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{1C2C22B6-C3F1-4376-90A1-46B46669BFEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1C2C22B6-C3F1-4376-90A1-46B46669BFEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C2C22B6-C3F1-4376-90A1-46B46669BFEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2225358D-0A9F-4AB4-B678-B22FE5E1A8CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2225358D-0A9F-4AB4-B678-B22FE5E1A8CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2225358D-0A9F-4AB4-B678-B22FE5E1A8CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2225358D-0A9F-4AB4-B678-B22FE5E1A8CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/HttpStream/HttpStream.cs
+++ b/HttpStream/HttpStream.cs
@@ -253,7 +253,7 @@ namespace Espresso3389.HttpStream
 
             var s = await res.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
-            int size32 = (int)size;
+            int size32 = size == long.MaxValue ? int.MaxValue : (int)size;
             stream.Position = begin;
             var buf = new byte[BufferingSize];
             var copied = 0;

--- a/HttpStream/HttpStream.csproj
+++ b/HttpStream/HttpStream.csproj
@@ -17,6 +17,7 @@
     <RepositoryUrl>https://github.com/espresso3389/HttpStream</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\"/>

--- a/HttpStreamTest/HttpStreamTest.csproj
+++ b/HttpStreamTest/HttpStreamTest.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HttpStreamTest/Program.cs
+++ b/HttpStreamTest/Program.cs
@@ -1,15 +1,16 @@
 ﻿using Espresso3389.HttpStream;
 using System;
+using System.Threading.Tasks;
 
 namespace HttpStreamTest
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             try
             {
-                var httpStream = new HttpStream(new Uri(args[0]));
+                var httpStream = await HttpStream.CreateAsync(new Uri(args[0]));
                 var size = (int)httpStream.Length;
                 var first = Math.Min(1024, size);
                 var second = size - first;


### PR DESCRIPTION
When the `Content-Length` HTTP header is not available, `HttpStream` would fail to read the data.

A new unit test project was added in 33975f4861c06b5fd213eb2cd07f4fe362a4b2d3 then GitHub Actions have been configured to run the tests and generate a report in af9e60e12de371f092e068c8437662f386a89fda.

Here are the results [before the fix](https://github.com/0xced/HttpStream/actions/runs/17909617283):

### 4 passed, 1 failed and 0 skipped ![Tests failed](https://img.shields.io/badge/tests-4%20passed%2C%201%20failed-critical)
<details><summary>Expand for details</summary>

|Report|Passed|Failed|Skipped|Time|
|:---|---:|---:|---:|---:|
|[TestResults-net8.0.trx](#user-content-r0)|4 ✅|1 ❌||3s|
## ❌ <a id="user-content-r0" href="#user-content-r0">TestResults-net8.0.trx</a>
**5** tests were completed in **3s** with **4** passed, **1** failed and **0** skipped.
|Test suite|Passed|Failed|Skipped|Time|
|:---|---:|---:|---:|---:|
|[HttpStreamTests.HttpStreamTest](#user-content-r0s0)|4 ✅|1 ❌||424ms|
### ❌ <a id="user-content-r0s0" href="#user-content-r0s0">HttpStreamTests.HttpStreamTest</a>
```
❌ TestDecompressionMethod(automaticDecompression: All)
	Expected value to be 100L, but found 0L (difference of -100).
	   at AwesomeAssertions.Execution.LateBoundTestFramework.Throw(String message)
	   at AwesomeAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
	   at AwesomeAssertions.Execution.AssertionScope.AddPreFormattedFailure(String formattedFailureMessage)
	   at AwesomeAssertions.Execution.AssertionChain.FailWith(Func`1 getFailureReason)
	   at AwesomeAssertions.Execution.AssertionChain.FailWith(Func`1 getFailureReason)
	   at AwesomeAssertions.Execution.AssertionChain.FailWith(String message, Object[] args)
	   at AwesomeAssertions.Numeric.NumericAssertionsBase`3.Be(T expected, String because, Object[] becauseArgs)
	   at HttpStreamTests.HttpStreamTest.TestDecompressionMethod(DecompressionMethods automaticDecompression) in /_/HttpStream.Tests/HttpStreamTest.cs:line 46
	   at HttpStreamTests.HttpStreamTest.TestDecompressionMethod(DecompressionMethods automaticDecompression) in /_/HttpStream.Tests/HttpStreamTest.cs:line 47
	--- End of stack trace from previous location ---
✅ TestDecompressionMethod(automaticDecompression: None)
✅ TestSize(size: 32767)
✅ TestSize(size: 32768)
✅ TestSize(size: 32769)
```
</details>

And here are the results [after the fix](https://github.com/0xced/HttpStream/actions/runs/17909695448):
### 5 passed, 0 failed and 0 skipped ![Tests passed successfully](https://img.shields.io/badge/tests-5%20passed-success)
<details><summary>Expand for details</summary>
 
|Report|Passed|Failed|Skipped|Time|
|:---|---:|---:|---:|---:|
|[TestResults-net8.0.trx](#user-content-r0)|5 ✅|||3s|
## ✅ <a id="user-content-r0" href="#user-content-r0">TestResults-net8.0.trx</a>
**5** tests were completed in **3s** with **5** passed, **0** failed and **0** skipped.
|Test suite|Passed|Failed|Skipped|Time|
|:---|---:|---:|---:|---:|
|[HttpStreamTests.HttpStreamTest](#user-content-r0s0)|5 ✅|||346ms|
### ✅ <a id="user-content-r0s0" href="#user-content-r0s0">HttpStreamTests.HttpStreamTest</a>
```
✅ TestDecompressionMethod(automaticDecompression: All)
✅ TestDecompressionMethod(automaticDecompression: None)
✅ TestSize(size: 32767)
✅ TestSize(size: 32768)
✅ TestSize(size: 32769)
```
</details>