### PR TITLE
Simplify response parsing by using the typed HttpClient headers

### DIFF
--- a/HttpStream.Tests/HttpStreamTest.cs
+++ b/HttpStream.Tests/HttpStreamTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -61,5 +62,16 @@ public class HttpStreamTest(WebAppFixture webApp) : IClassFixture<WebAppFixture>
         await httpStream.CopyToAsync(memoryStream);
         memoryStream.Length.Should().Be(60);
         memoryStream.ToArray().Should().OnlyContain(b => b == 'A');
+    }
+
+    [Fact]
+    public async Task TestNotFound()
+    {
+        var uri = new Uri(webApp.GetBytesUri(100).AbsoluteUri.Replace("/bytes/", "/not_found/"));
+        await using var httpStream = await HttpStream.CreateAsync(uri);
+
+        var action = () => httpStream.CopyToAsync(Stream.Null);
+
+        (await action.Should().ThrowExactlyAsync<HttpRequestException>()).WithMessage("Response status code does not indicate success for bytes=0-32767: 404 (Not Found).");
     }
 }

--- a/HttpStream.Tests/HttpStreamTest.cs
+++ b/HttpStream.Tests/HttpStreamTest.cs
@@ -46,4 +46,20 @@ public class HttpStreamTest(WebAppFixture webApp) : IClassFixture<WebAppFixture>
         memoryStream.Length.Should().Be(size);
         memoryStream.ToArray().Should().OnlyContain(b => b == 'A');
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TestSeek(bool enableRangeProcessing)
+    {
+        var uri = webApp.GetBytesUri(100, enableRangeProcessing);
+        await using var httpStream = await HttpStream.CreateAsync(uri, cache: new MemoryStream(), ownStream: true, cachePageSize: 32, cached: null);
+
+        httpStream.Seek(40, SeekOrigin.Begin);
+
+        using var memoryStream = new MemoryStream();
+        await httpStream.CopyToAsync(memoryStream);
+        memoryStream.Length.Should().Be(60);
+        memoryStream.ToArray().Should().OnlyContain(b => b == 'A');
+    }
 }

--- a/HttpStream.Tests/WebAppFixture.cs
+++ b/HttpStream.Tests/WebAppFixture.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Net.Mime;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -25,17 +24,18 @@ public class WebAppFixture : IAsyncLifetime
 
         _webApp = webAppBuilder.Build();
         _webApp.UseResponseCompression();
-        _webApp.MapMethods("/bytes/{size:int}", [HttpMethods.Get, HttpMethods.Head], (int size) => TypedResults.File(Enumerable.Repeat(Convert.ToByte('A'), size).ToArray(), MediaTypeNames.Text.Plain));
+        _webApp.MapMethods("/bytes/{size:int}", [HttpMethods.Get, HttpMethods.Head], (int size, bool enableRangeProcessing = true) => TypedResults.File(Enumerable.Repeat(Convert.ToByte('A'), size).ToArray(), "text/plain; charset=utf-8", enableRangeProcessing: enableRangeProcessing));
     }
 
     /// <summary>
     /// Returns a URI that sends a <c>text/plain</c> response of the character <c>A</c> repeated <paramref name="size"/> times.
     /// </summary>
     /// <param name="size">The size of the response content in bytes.</param>
-    public Uri GetBytesUri(int size)
+    /// <param name="enableRangeProcessing">Whether range processing is enabled or not.</param>
+    public Uri GetBytesUri(int size, bool enableRangeProcessing = true)
     {
         var baseUri = _uri ?? throw new InvalidOperationException($"The URI is only available after {nameof(IAsyncLifetime.InitializeAsync)} has been called");
-        return new Uri(baseUri, $"/bytes/{size}");
+        return new Uri(baseUri, $"/bytes/{size}?enableRangeProcessing={enableRangeProcessing}");
     }
 
     async Task IAsyncLifetime.InitializeAsync()

--- a/HttpStream/CacheStream.cs
+++ b/HttpStream/CacheStream.cs
@@ -66,7 +66,7 @@ namespace Espresso3389.HttpStream
         {
             if (DispatcherInvoker == null)
             {
-                return func().Result;
+                return func().GetAwaiter().GetResult();
             }
 
             T? ret = default(T);

--- a/HttpStream/HttpStream.cs
+++ b/HttpStream/HttpStream.cs
@@ -200,7 +200,12 @@ namespace Espresso3389.HttpStream
             LastHttpStatusCode = res.StatusCode;
             LastReasonPhrase = res.ReasonPhrase;
             if (!res.IsSuccessStatusCode)
-                throw new Exception($"HTTP Status: {res.StatusCode} for bytes={offset}-{endPos - 1}");
+            {
+                var message = string.IsNullOrWhiteSpace(res.ReasonPhrase)
+                    ? $"Response status code does not indicate success for {req.Headers.Range}: {(int)res.StatusCode}."
+                    : $"Response status code does not indicate success for {req.Headers.Range}: {(int)res.StatusCode} ({res.ReasonPhrase}).";
+                throw new HttpRequestException(message);
+            }
 
             // retrieve the resulting Content-Range
             bool getRanges;

--- a/HttpStream/HttpStream.cs
+++ b/HttpStream/HttpStream.cs
@@ -1,11 +1,8 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
-using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using System.Globalization;
-using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace Espresso3389.HttpStream
@@ -195,8 +192,8 @@ namespace Espresso3389.HttpStream
                 endPos = StreamLength;
 
             var req = new HttpRequestMessage(HttpMethod.Get, _uri);
-            // Use "Range" header to sepcify the data offset and size
-            req.Headers.Add("Range", $"bytes={offset}-{endPos - 1}");
+            // Use "Range" header to specify the data offset and size
+            req.Headers.Range = new RangeHeaderValue(offset, endPos - 1);
 
             // post the request
             var res = await _httpClient.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
@@ -206,48 +203,37 @@ namespace Espresso3389.HttpStream
                 throw new Exception($"HTTP Status: {res.StatusCode} for bytes={offset}-{endPos - 1}");
 
             // retrieve the resulting Content-Range
-            bool getRanges = true;
-            long begin = 0, end;
+            bool getRanges;
+            long begin;
             long size = long.MaxValue;
-            if (!actionIfFound(res, "Content-Range", range =>
+            var contentRange = res.Content.Headers.ContentRange;
+            if (contentRange is { From: not null, To: not null })
             {
                 // 206
-                var m = Regex.Match(range, @"bytes\s+([0-9]+)-([0-9]+)/(\w+)");
-                begin = long.Parse(m.Groups[1].Value);
-                end = long.Parse(m.Groups[2].Value);
-                size = end - begin + 1;
+                getRanges = true;
+                begin = contentRange.From.Value;
+                size = contentRange.To.Value - begin + 1;
 
-                if (!IsStreamLengthAvailable)
+                if (!IsStreamLengthAvailable && contentRange.Length.HasValue)
                 {
-                    var sz = m.Groups[3].Value;
-                    if (sz != "*")
-                    {
-                        StreamLength = long.Parse(sz);
-                        IsStreamLengthAvailable = true;
-                    }
+                    StreamLength = contentRange.Length.Value;
+                    IsStreamLengthAvailable = true;
                 }
-            }))
+            }
+            else
             {
-                // In some case, there's no Content-Range but Content-Length
-                // instead.
+                // In some case, there's no Content-Range but Content-Length instead.
                 getRanges = false;
                 begin = 0;
-                actionIfFound(res, "Content-Length", v =>
+                if (res.Content.Headers.ContentLength.HasValue)
                 {
-                    StreamLength = end = size = long.Parse(v);
+                    StreamLength = size = res.Content.Headers.ContentLength.Value;
                     IsStreamLengthAvailable = true;
-                });
+                }
             }
 
-            actionIfFound(res, "Content-Type", v =>
-            {
-                ContentType = v;
-            });
-
-            actionIfFound(res, "Last-Modified", v =>
-            {
-                LastModified = parseDateTime(v);
-            });
+            ContentType = res.Content.Headers.ContentType?.ToString();
+            LastModified = res.Content.Headers.LastModified?.DateTime ?? default;
 
             InspectionFinished = true;
 
@@ -279,36 +265,10 @@ namespace Espresso3389.HttpStream
             return copied;
         }
 
-        bool actionIfFound(HttpResponseMessage res, string name, Action<string> action)
-        {
-            IEnumerable<string> strs;
-            if (res.Content.Headers.TryGetValues(name, out strs))
-            {
-                action(strs.First());
-                return true;
-            }
-            return false;
-        }
-
         /// <summary>
         /// Invoked when a new range is downloaded.
         /// </summary>
         public event EventHandler<RangeDownloadedEventArgs>? RangeDownloaded;
-
-        static DateTime parseDateTime(string dateTime)
-        {
-            if (dateTime.EndsWith(" UTC"))
-            {
-                return DateTime.ParseExact(dateTime,
-                    "ddd, dd MMM yyyy HH:mm:ss 'UTC'",
-                    CultureInfo.InvariantCulture.DateTimeFormat,
-                    DateTimeStyles.AssumeUniversal);
-            }
-            return DateTime.ParseExact(dateTime,
-                "ddd, dd MMM yyyy HH:mm:ss 'GMT'",
-                CultureInfo.InvariantCulture.DateTimeFormat,
-                DateTimeStyles.AssumeUniversal);
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
The `HttpClient` class provides typed headers so that manual parsing of the HTTP header values is not needed.

Also, throw [HttpRequestException](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httprequestexception) instead of the base `System.Exception` exception in case of non successful HTTP status code.

Finally, use `.GetAwaiter().GetResult()` instead of `.Result` in order to avoid wrapping the exception inside an `AggregateException`.